### PR TITLE
chore: devcontainer設定を最新化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,28 +3,22 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+	"image": "mcr.microsoft.com/devcontainers/python:3.14",
 	"customizations": {
 		"vscode": {
 			"extensions": [
 				"vsls-contrib.codetour",
-				"GitHub.copilot",
 				"GitHub.copilot-chat"
-			],
-			"settings": {
-				"github.copilot.chat.mcp.discovery.enabled": true
-			}
+			]
 		}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers/features/node:1": {}
-	},
-
-	// Install GitHub Copilot CLI after container creation
-	"postCreateCommand": "gh extension install github/gh-copilot || true && npm install -g @github/copilot || true"
+		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/copilot-cli:1": {}
+	}
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],


### PR DESCRIPTION
- Python イメージを 3.11 → 3.14 に更新
- GitHub.copilot 拡張依存を削除しGitHub.copilot-chatのみに
- github.copilot.chat.mcp.discovery.enabled 設定を削除
- Copilot CLI を postCreateCommand から devcontainer feature に移行